### PR TITLE
Use primary key instead of hard-coding `id`

### DIFF
--- a/payments_mercadopago/__init__.py
+++ b/payments_mercadopago/__init__.py
@@ -32,7 +32,7 @@ class MercadoPagoProvider(BasicProvider):
         super(MercadoPagoProvider, self).__init__(**kwargs)
 
     def get_form(self, payment, data=None, file_data=None):
-        if not payment.id:
+        if not payment.pk:
             payment.save()
         payment_data = self.create_payment(payment)
         redirect_to = self.get_value_from_response(


### PR DESCRIPTION
`BasePayment` doesn't specify a primary key, so it will use whatever is defined in the non-abstract class.

This is frequently `id`, but can be any value (I use `uuid` in a few apps of mine).

This tiny change makes the provider use the `pk` alias, instead of hardcoding `id`. This is functionally equivalent if your primary key is `id`, but also works if your primary key is `uuid` or anything else.